### PR TITLE
fixes import error from '@clerk/remix' at edge

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -11,7 +11,14 @@ import type { LinksFunction, LoaderFunction } from "@vercel/remix";
 
 export const ErrorBoundary = ClerkErrorBoundary();
 
-export const loader: LoaderFunction = (args) => rootAuthLoader(args);
+// Circumvent process.env replacement during build
+const global = globalThis;
+const globalEnv = global.process.env;
+
+export const loader: LoaderFunction = (args) => rootAuthLoader(args,{
+  publishableKey: globalEnv.CLERK_PUBLISHABLE_KEY,
+  secretKey: globalEnv.CLERK_SECRET_KEY
+});
 
 export function Layout({ children }: { children: React.ReactNode }) {
   return (

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@remix-run/node": "^2.8.1",
     "@remix-run/react": "^2.8.1",
     "@remix-run/serve": "^2.8.1",
+    "@remix-run/server-runtime": "^2.8.1",
     "isbot": "^5.1.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@remix-run/serve':
     specifier: ^2.8.1
     version: 2.8.1(typescript@5.4.2)
+  '@remix-run/server-runtime':
+    specifier: ^2.8.1
+    version: 2.8.1(typescript@5.4.2)
   isbot:
     specifier: ^5.1.1
     version: 5.1.1

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,6 +5,10 @@ import tsconfigPaths from "vite-tsconfig-paths";
 import { vercelPreset } from "@vercel/remix/vite";
 installGlobals();
 
-export default defineConfig({
-  plugins: [remix({ presets: [vercelPreset()] }), tsconfigPaths()],
-});
+export default defineConfig(({ mode }) => ({
+	plugins: [remix({ presets: [vercelPreset()] }), tsconfigPaths()],
+	ssr:
+		mode === "production"
+			? { noExternal: true, target: "webworker" }
+			: undefined,
+}));


### PR DESCRIPTION
I had the same issue and a google search of the error landed me here.

The issue was `@clerk/backend` using import maps to resolve `#crypto` & `#fetch`, and vercel runtime is somehow not able to resolve it.

If we bundle everything during build, `vite` will resolve everything properly. 